### PR TITLE
Refactor/remove tag id from todo

### DIFF
--- a/src/ToDoManager.Api/Controllers/TodosController.cs
+++ b/src/ToDoManager.Api/Controllers/TodosController.cs
@@ -182,11 +182,8 @@ public class TodosController : ApiController
 	[HttpDelete("{todoId}/tags/{tagId}")]
 	public async Task<IActionResult> RemoveTagIdFromTodo(Guid todoId, Guid tagId)
 	{
-		var stronglyTypedTodoId = TodoId.Create(todoId);
-		var stronglyTypedTagId = TagId.Create(todoId);
-		
 		var result = await _sender
-			.Send(new RemoveTagIdFromTodoCommand( stronglyTypedTodoId, stronglyTypedTagId));
+			.Send(new RemoveTagIdFromTodoCommand(todoId, tagId));
 
 		return result.Match(
 			_ => NoContent(),

--- a/src/ToDoManager.Application/Todos/Commands/RemoveTagIdFromTodo/RemoveTagIdFromTodoCommand.cs
+++ b/src/ToDoManager.Application/Todos/Commands/RemoveTagIdFromTodo/RemoveTagIdFromTodoCommand.cs
@@ -5,5 +5,5 @@ using ToDoManager.Domain.Todos.ValueObjects;
 
 namespace ToDoManager.Application.Todos.Commands.RemoveTagIdFromTodo;
 
-public record RemoveTagIdFromTodoCommand(TodoId TodoId, TagId TagId) 
+public record RemoveTagIdFromTodoCommand(Guid TodoId, Guid TagId) 
 	: IRequest<ErrorOr<Unit>>;

--- a/src/ToDoManager.Application/Todos/Commands/RemoveTagIdFromTodo/RemoveTagIdFromTodoCommandHandler.cs
+++ b/src/ToDoManager.Application/Todos/Commands/RemoveTagIdFromTodo/RemoveTagIdFromTodoCommandHandler.cs
@@ -28,18 +28,25 @@ public class RemoveTagIdFromTodoCommandHandler : IRequestHandler<RemoveTagIdFrom
 	{
 		var currentUserId = _userAccessor.GetId();
 
-		var queryResult = await GetTodoByIdForUserAsync(request.TodoId, currentUserId);
+		var todoId = ToTodoId(request.TodoId);
+
+		var queryResult = await GetTodoByIdForUserAsync(todoId, currentUserId);
 
 		if (queryResult.IsError) return queryResult.Errors;
 
 		var todo = queryResult.Value;
+
+		var tagId = ToTagId(request.TagId);
 		
-		todo.RemoveTagId(request.TagId);
+		todo.RemoveTagId(tagId);
 
 		var persistenceResult = await _unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return EnsurePersistenceResult(persistenceResult);
 	}
+	
+	private static TodoId ToTodoId(Guid primitiveTodoId) => TodoId.Create(primitiveTodoId);
+	private static TagId ToTagId(Guid primitiveTagId) => TagId.Create(primitiveTagId);
 
 	private async Task<ErrorOr<Todo>> GetTodoByIdForUserAsync(TodoId todoId, UserId userId)
 	{


### PR DESCRIPTION
Apply ids with primitive types in RemoveTagFromTodo command; strongly typed ids was implemented in RemoveTagFromTodo action (TodosController) and the command handler

The logic for strongly typed id in the handler was encapsulated 